### PR TITLE
Add helper functions for grouped IEs

### DIFF
--- a/ie/application-id.go
+++ b/ie/application-id.go
@@ -25,6 +25,17 @@ func (i *IE) ApplicationID() (string, error) {
 			}
 		}
 		return "", ErrIENotFound
+	case ApplicationDetectionInformation:
+		ies, err := i.ApplicationDetectionInformation()
+		if err != nil {
+			return "", err
+		}
+		for _, x := range ies {
+			if x.Type == ApplicationID {
+				return x.ApplicationID()
+			}
+		}
+		return "", ErrIENotFound
 	default:
 		return "", ErrInvalidType
 	}

--- a/ie/application-id.go
+++ b/ie/application-id.go
@@ -37,6 +37,6 @@ func (i *IE) ApplicationID() (string, error) {
 		}
 		return "", ErrIENotFound
 	default:
-		return "", ErrInvalidType
+		return "", &InvalidTypeError{Type: i.Type}
 	}
 }

--- a/ie/application-id.go
+++ b/ie/application-id.go
@@ -11,9 +11,21 @@ func NewApplicationID(instance string) *IE {
 
 // ApplicationID returns ApplicationID in string if the type of IE matches.
 func (i *IE) ApplicationID() (string, error) {
-	if i.Type != ApplicationID {
-		return "", &InvalidTypeError{Type: i.Type}
+	switch i.Type {
+	case ApplicationID:
+		return string(i.Payload), nil
+	case ApplicationIDsPFDs:
+		ies, err := i.ApplicationIDsPFDs()
+		if err != nil {
+			return "", err
+		}
+		for _, x := range ies {
+			if x.Type == ApplicationID {
+				return x.ApplicationID()
+			}
+		}
+		return "", ErrIENotFound
+	default:
+		return "", ErrInvalidType
 	}
-
-	return string(i.Payload), nil
 }

--- a/ie/application-instance-id.go
+++ b/ie/application-instance-id.go
@@ -11,9 +11,21 @@ func NewApplicationInstanceID(id string) *IE {
 
 // ApplicationInstanceID returns ApplicationInstanceID in string if the type of IE matches.
 func (i *IE) ApplicationInstanceID() (string, error) {
-	if i.Type != ApplicationInstanceID {
-		return "", &InvalidTypeError{Type: i.Type}
+	switch i.Type {
+	case ApplicationInstanceID:
+		return string(i.Payload), nil
+	case ApplicationDetectionInformation:
+		ies, err := i.ApplicationDetectionInformation()
+		if err != nil {
+			return "", err
+		}
+		for _, x := range ies {
+			if x.Type == ApplicationInstanceID {
+				return x.ApplicationInstanceID()
+			}
+		}
+		return "", ErrIENotFound
+	default:
+		return "", ErrInvalidType
 	}
-
-	return string(i.Payload), nil
 }

--- a/ie/application-instance-id.go
+++ b/ie/application-instance-id.go
@@ -26,6 +26,6 @@ func (i *IE) ApplicationInstanceID() (string, error) {
 		}
 		return "", ErrIENotFound
 	default:
-		return "", ErrInvalidType
+		return "", &InvalidTypeError{Type: i.Type}
 	}
 }

--- a/ie/bar-id.go
+++ b/ie/bar-id.go
@@ -15,12 +15,25 @@ func NewBARID(id uint8) *IE {
 
 // BARID returns BARID in uint8 if the type of IE matches.
 func (i *IE) BARID() (uint8, error) {
-	if i.Type != BARID {
+	switch i.Type {
+	case BARID:
+		if len(i.Payload) < 1 {
+			return 0, io.ErrUnexpectedEOF
+		}
+
+		return i.Payload[0], nil
+	case QueryURR:
+		ies, err := i.QueryURR()
+		if err != nil {
+			return 0, err
+		}
+		for _, x := range ies {
+			if x.Type == BARID {
+				return x.BARID()
+			}
+		}
+		return 0, ErrIENotFound
+	default:
 		return 0, &InvalidTypeError{Type: i.Type}
 	}
-	if len(i.Payload) < 1 {
-		return 0, io.ErrUnexpectedEOF
-	}
-
-	return i.Payload[0], nil
 }

--- a/ie/flow-information.go
+++ b/ie/flow-information.go
@@ -47,7 +47,7 @@ func (i *IE) FlowInformation() ([]byte, error) {
 		}
 		return nil, ErrIENotFound
 	default:
-		return nil, ErrInvalidType
+		return nil, &InvalidTypeError{Type: i.Type}
 	}
 }
 
@@ -68,7 +68,7 @@ func (i *IE) FlowDirection() (uint8, error) {
 		}
 		return 0, ErrIENotFound
 	default:
-		return 0, ErrInvalidType
+		return 0, &InvalidTypeError{Type: i.Type}
 	}
 }
 
@@ -94,6 +94,6 @@ func (i *IE) FlowDescription() (string, error) {
 		}
 		return "", ErrIENotFound
 	default:
-		return "", ErrInvalidType
+		return "", &InvalidTypeError{Type: i.Type}
 	}
 }

--- a/ie/flow-information.go
+++ b/ie/flow-information.go
@@ -32,38 +32,68 @@ func NewFlowInformation(dir uint8, desc string) *IE {
 
 // FlowInformation returns FlowInformation in []byte if the type of IE matches.
 func (i *IE) FlowInformation() ([]byte, error) {
-	if i.Type != FlowInformation {
-		return nil, &InvalidTypeError{Type: i.Type}
+	switch i.Type {
+	case FlowInformation:
+		return i.Payload, nil
+	case ApplicationDetectionInformation:
+		ies, err := i.ApplicationDetectionInformation()
+		if err != nil {
+			return nil, err
+		}
+		for _, x := range ies {
+			if x.Type == FlowInformation {
+				return x.FlowInformation()
+			}
+		}
+		return nil, ErrIENotFound
+	default:
+		return nil, ErrInvalidType
 	}
-
-	return i.Payload, nil
 }
 
 // FlowDirection returns FlowDirection in uint8 if the type of IE matches.
 func (i *IE) FlowDirection() (uint8, error) {
-	if i.Type != FlowInformation {
-		return 0, &InvalidTypeError{Type: i.Type}
+	switch i.Type {
+	case FlowInformation:
+		return i.Payload[0] & 0x07, nil
+	case ApplicationDetectionInformation:
+		ies, err := i.ApplicationDetectionInformation()
+		if err != nil {
+			return 0, err
+		}
+		for _, x := range ies {
+			if x.Type == FlowInformation {
+				return x.FlowDirection()
+			}
+		}
+		return 0, ErrIENotFound
+	default:
+		return 0, ErrInvalidType
 	}
-	if len(i.Payload) < 1 {
-		return 0, io.ErrUnexpectedEOF
-	}
-
-	return i.Payload[0] & 0x07, nil
 }
 
 // FlowDescription returns FlowDescription in string if the type of IE matches.
 func (i *IE) FlowDescription() (string, error) {
-	if i.Type != FlowInformation {
-		return "", &InvalidTypeError{Type: i.Type}
-	}
-	if len(i.Payload) < 3 {
-		return "", io.ErrUnexpectedEOF
-	}
-	l := binary.BigEndian.Uint16(i.Payload[1:3])
+	switch i.Type {
+	case FlowInformation:
+		l := binary.BigEndian.Uint16(i.Payload[1:3])
+		if len(i.Payload) < int(l) {
+			return "", io.ErrUnexpectedEOF
+		}
 
-	if len(i.Payload) < int(l) {
-		return "", io.ErrUnexpectedEOF
+		return string(i.Payload[4:l]), nil
+	case ApplicationDetectionInformation:
+		ies, err := i.ApplicationDetectionInformation()
+		if err != nil {
+			return "", err
+		}
+		for _, x := range ies {
+			if x.Type == FlowInformation {
+				return x.FlowDescription()
+			}
+		}
+		return "", ErrIENotFound
+	default:
+		return "", ErrInvalidType
 	}
-
-	return string(i.Payload[4:l]), nil
 }

--- a/ie/flow-information.go
+++ b/ie/flow-information.go
@@ -55,6 +55,9 @@ func (i *IE) FlowInformation() ([]byte, error) {
 func (i *IE) FlowDirection() (uint8, error) {
 	switch i.Type {
 	case FlowInformation:
+		if len(i.Payload) < 1 {
+			return 0, io.ErrUnexpectedEOF
+		}
 		return i.Payload[0] & 0x07, nil
 	case ApplicationDetectionInformation:
 		ies, err := i.ApplicationDetectionInformation()

--- a/ie/ie_test.go
+++ b/ie/ie_test.go
@@ -281,7 +281,9 @@ func TestIEs(t *testing.T) {
 			"ApplicationIDsPFDs",
 			ie.NewApplicationIDsPFDs(
 				ie.NewApplicationID("https://github.com/wmnsk/go-pfcp/"),
-				ie.NewPFDContext(ie.NewPFDContents("aa", "bb", "cc", "dd", "ee", []string{"11", "22"}, []string{"33", "44"}, []string{"55", "66"})),
+				ie.NewPFDContext(
+					ie.NewPFDContents("aa", "bb", "cc", "dd", "ee", []string{"11", "22"}, []string{"33", "44"}, []string{"55", "66"}),
+				),
 			),
 			[]byte{
 				0x00, 0x3a, 0x00, 0x61,
@@ -302,7 +304,9 @@ func TestIEs(t *testing.T) {
 			},
 		}, {
 			"PFDContext",
-			ie.NewPFDContext(ie.NewPFDContents("aa", "bb", "cc", "dd", "ee", []string{"11", "22"}, []string{"33", "44"}, []string{"55", "66"})),
+			ie.NewPFDContext(
+				ie.NewPFDContents("aa", "bb", "cc", "dd", "ee", []string{"11", "22"}, []string{"33", "44"}, []string{"55", "66"}),
+			),
 			[]byte{
 				0x00, 0x3b, 0x00, 0x38,
 				0x00, 0x3d, 0x00, 0x34,

--- a/ie/metric.go
+++ b/ie/metric.go
@@ -28,10 +28,20 @@ func (i *IE) Metric() (uint8, error) {
 		if err != nil {
 			return 0, err
 		}
-
-		for _, e := range ies {
-			if e.Type == Metric {
-				return e.Metric()
+		for _, x := range ies {
+			if x.Type == Metric {
+				return x.Metric()
+			}
+		}
+		return 0, ErrIENotFound
+	case OverloadControlInformation:
+		ies, err := i.OverloadControlInformation()
+		if err != nil {
+			return 0, err
+		}
+		for _, x := range ies {
+			if x.Type == Metric {
+				return x.Metric()
 			}
 		}
 		return 0, ErrIENotFound

--- a/ie/oci-flags.go
+++ b/ie/oci-flags.go
@@ -15,12 +15,25 @@ func NewOCIFlags(flags uint8) *IE {
 
 // OCIFlags returns OCIFlags in uint8 if the type of IE matches.
 func (i *IE) OCIFlags() (uint8, error) {
-	if i.Type != OCIFlags {
-		return 0, &InvalidTypeError{Type: i.Type}
-	}
 	if len(i.Payload) < 1 {
 		return 0, io.ErrUnexpectedEOF
 	}
 
-	return i.Payload[0], nil
+	switch i.Type {
+	case OCIFlags:
+		return i.Payload[0], nil
+	case OverloadControlInformation:
+		ies, err := i.OverloadControlInformation()
+		if err != nil {
+			return 0, err
+		}
+		for _, x := range ies {
+			if x.Type == OCIFlags {
+				return x.OCIFlags()
+			}
+		}
+		return 0, ErrIENotFound
+	default:
+		return 0, &InvalidTypeError{Type: i.Type}
+	}
 }

--- a/ie/packet-detection-rule-id.go
+++ b/ie/packet-detection-rule-id.go
@@ -6,6 +6,7 @@ package ie
 
 import (
 	"encoding/binary"
+	"io"
 )
 
 // NewPacketDetectionRuleID creates a new PacketDetectionRuleID IE.
@@ -17,6 +18,9 @@ func NewPacketDetectionRuleID(id uint16) *IE {
 func (i *IE) PacketDetectionRuleID() (uint16, error) {
 	switch i.Type {
 	case PacketDetectionRuleID:
+		if len(i.Payload) < 2 {
+			return 0, io.ErrUnexpectedEOF
+		}
 		return binary.BigEndian.Uint16(i.Payload[0:2]), nil
 	case ApplicationDetectionInformation:
 		ies, err := i.ApplicationDetectionInformation()

--- a/ie/packet-detection-rule-id.go
+++ b/ie/packet-detection-rule-id.go
@@ -30,6 +30,6 @@ func (i *IE) PacketDetectionRuleID() (uint16, error) {
 		}
 		return 0, ErrIENotFound
 	default:
-		return 0, ErrInvalidType
+		return 0, &InvalidTypeError{Type: i.Type}
 	}
 }

--- a/ie/sequence-number.go
+++ b/ie/sequence-number.go
@@ -28,10 +28,20 @@ func (i *IE) SequenceNumber() (uint32, error) {
 		if err != nil {
 			return 0, err
 		}
-
-		for _, e := range ies {
-			if e.Type == SequenceNumber {
-				return e.SequenceNumber()
+		for _, x := range ies {
+			if x.Type == SequenceNumber {
+				return x.SequenceNumber()
+			}
+		}
+		return 0, ErrIENotFound
+	case OverloadControlInformation:
+		ies, err := i.OverloadControlInformation()
+		if err != nil {
+			return 0, err
+		}
+		for _, x := range ies {
+			if x.Type == SequenceNumber {
+				return x.SequenceNumber()
 			}
 		}
 		return 0, ErrIENotFound


### PR DESCRIPTION
To retrieve needed values from a grouped IE quickly, some helper methods for some IEs return the value if the type of IE matches to the IE that may include that type.

For example, `URRID()` now returns the value in uint32 if it's called on QueryURR IE as well as on URRID IE.