### PR TITLE
Fix OuterHeaderCreation parse initial offset

### DIFF
--- a/ie/outer-header-creation.go
+++ b/ie/outer-header-creation.go
@@ -287,7 +287,7 @@ func (f *OuterHeaderCreationFields) UnmarshalBinary(b []byte) error {
 	}
 
 	f.OuterHeaderCreationDescription = binary.BigEndian.Uint16(b[0:2])
-	offset := 3
+	offset := 2
 
 	oct5 := b[0]
 	if has1stBit(oct5) || has2ndBit(oct5) {


### PR DESCRIPTION
This change fixes incorrect offset computation to the start of the Outer Header Creation IE parsing.

![image](https://user-images.githubusercontent.com/3656722/86309410-84926600-bbd0-11ea-8ca2-1f661046f2a2.png)
