### PR TITLE
Add project-wide logger for informational logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/wmnsk/go-pfcp
 go 1.14
 
 require (
-	github.com/google/go-cmp v0.4.1
+	github.com/google/go-cmp v0.5.1
 	github.com/pascaldekloe/goe v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
-github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
+github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/ie/ie.go
+++ b/ie/ie.go
@@ -7,6 +7,8 @@ package ie
 import (
 	"encoding/binary"
 	"io"
+
+	"github.com/wmnsk/go-pfcp/internal/logger"
 )
 
 // IE Type definitions.
@@ -568,7 +570,7 @@ func newGroupedIE(itype, eid uint16, ies ...*IE) *IE {
 
 		serialized, err := ie.Marshal()
 		if err != nil {
-			// TODO: log error
+			logger.Logf("newGroupedIE() failed to marshal an IE(Type=%d): %v", ie.Type, err)
 			return nil
 		}
 		i.Payload = append(i.Payload, serialized...)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,80 @@
+// Copyright 2019-2020 go-pfcp authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+// Package logger provides a logging functionalities for go-pfcp.
+//
+// This is hidden here to be able to be imported from each package of go-pfcp.
+package logger
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"sync"
+)
+
+var (
+	logger = log.New(os.Stderr, "", log.LstdFlags)
+	logMu  sync.Mutex
+)
+
+// SetLogger replaces the standard logger with arbitrary *log.Logger.
+//
+// DON'T CALL THIS. Use the func in pfcp package instead.
+//
+// This package prints just informational logs from goroutines working background
+// that might help developers test the program but can be ignored safely. More
+// important ones that needs any action by caller would be returned as errors.
+func SetLogger(l *log.Logger) {
+	if l == nil {
+		log.Println("Don't pass nil to SetLogger: use DisableLogging instead.")
+	}
+
+	setLogger(l)
+}
+
+// EnableLogging enables the logging from the package.
+//
+// DON'T CALL THIS. Use the func in pfcp package instead.
+//
+// If l is nil, it uses default logger provided by the package.
+// Logging is enabled by default.
+//
+// See also: SetLogger.
+func EnableLogging(l *log.Logger) {
+	logMu.Lock()
+	defer logMu.Unlock()
+
+	setLogger(l)
+}
+
+// DisableLogging disables the logging from the package.
+//
+// DON'T CALL THIS. Use the func in pfcp package instead.
+//
+// Logging is enabled by default.
+func DisableLogging() {
+	logMu.Lock()
+	defer logMu.Unlock()
+
+	logger.SetOutput(ioutil.Discard)
+}
+
+func setLogger(l *log.Logger) {
+	if l == nil {
+		l = log.New(os.Stderr, "", log.LstdFlags)
+	}
+
+	logMu.Lock()
+	defer logMu.Unlock()
+
+	logger = l
+}
+
+func Logf(format string, v ...interface{}) {
+	logMu.Lock()
+	defer logMu.Unlock()
+
+	logger.Printf(format, v...)
+}

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 go-pfcp authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package pfcp
+
+import (
+	"log"
+
+	"github.com/wmnsk/go-pfcp/internal/logger"
+)
+
+// SetLogger replaces the standard logger with arbitrary *log.Logger.
+//
+// This package prints just informational logs from goroutines working background
+// that might help developers test the program but can be ignored safely. More
+// important ones that need any action by the caller would be returned as errors.
+func SetLogger(l *log.Logger) {
+	logger.SetLogger(l)
+}
+
+// EnableLogging enables the logging from the package.
+//
+// If l is nil, it uses default logger provided by the package.
+// Logging is enabled by default.
+//
+// See also: SetLogger.
+func EnableLogging(l *log.Logger) {
+	logger.EnableLogging(l)
+}
+
+// DisableLogging disables the logging from the package.
+//
+// Logging is enabled by default.
+func DisableLogging() {
+	logger.DisableLogging()
+}

--- a/message/message.go
+++ b/message/message.go
@@ -4,7 +4,11 @@
 
 package message
 
-import "io"
+import (
+	"io"
+
+	"github.com/wmnsk/go-pfcp/internal/logger"
+)
 
 // MessageType definitions.
 const (
@@ -105,6 +109,7 @@ func Parse(b []byte) (Message, error) {
 	case MsgTypeSessionReportResponse:
 		m = &SessionReportResponse{}
 	default:
+		logger.Logf("Parse() got an unknown type of message(Type=%d), parsing with *Generic.", b[1])
 		m = &Generic{}
 	}
 

--- a/message/session-establishment-request_test.go
+++ b/message/session-establishment-request_test.go
@@ -5,7 +5,6 @@
 package message_test
 
 import (
-	"log"
 	"net"
 	"testing"
 	"time"
@@ -447,7 +446,6 @@ func TestSessionEstablishmentRequest(t *testing.T) {
 			return nil, err
 		}
 
-		log.Println(len(cases[0].Serialized))
 		v.Payload = nil
 		return v, nil
 	})


### PR DESCRIPTION
Sometimes we want to warn something trivial to users instead of returning errors. This PR implements a logger used in common in the whole project(go-pfcp) that can be disabled or replaced with another `log.Logger`.