### PR TITLE
Extract the right FARID filed in RemoveFAR request

### DIFF
--- a/ie/far-id.go
+++ b/ie/far-id.go
@@ -95,8 +95,7 @@ func (i *IE) FARID() (uint32, error) {
 			return 0, err
 		}
 		for _, x := range ies {
-			switch x.Type {
-			case TGPPAccessForwardingActionInformation, NonTGPPAccessForwardingActionInformation:
+			if x.Type == FARID {
 				return x.FARID()
 			}
 		}


### PR DESCRIPTION
This patch fixes retrieving of the right FARID from IE for a received RemoveFAR pfpc request.