### PR TITLE
UE IP Address length limit fix

### DIFF
--- a/ie/ue-ip-address.go
+++ b/ie/ue-ip-address.go
@@ -192,7 +192,7 @@ func ParseUEIPAddressFields(b []byte) (*UEIPAddressFields, error) {
 // UnmarshalBinary parses b into IE.
 func (f *UEIPAddressFields) UnmarshalBinary(b []byte) error {
 	l := len(b)
-	if l < 2 {
+	if l < 1 {
 		return io.ErrUnexpectedEOF
 	}
 


### PR DESCRIPTION
In case of UPF UE IP allocation feature support, UE IP address received from SMF would only contain the flag value CHV4 true. In that case length of UE IP address would 1 for the flags.
29.244 : 8.2.62 UE IP Address
Bit 5 – CHV4 (CHOOSE IPV4): If this bit is set to "1", then the V4 bit shall not be set, the IPv4 address shall
not be present and the UP function shall assign an IPv4 address. This bit shall only be set by the CP function.