### PR TITLE
In function Parse(), validating the len of b should be 2 instead of

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -56,7 +56,7 @@ type Message interface {
 
 // Parse parses the given bytes as Message.
 func Parse(b []byte) (Message, error) {
-	if len(b) < 1 {
+	if len(b) < 2 {
 		return nil, io.ErrUnexpectedEOF
 	}
 


### PR DESCRIPTION
In function Parse(), validating the len of b should be 2 instead of 1 due to array index start from 0, and also PFCP Message Type reside in array index 1 of a given byte stream.