### PR TITLE
The size of the OuterHeaderRemoval IE and GTPUExternsionHeaderDeletion handling

### DIFF
--- a/ie/outer-header-removal.go
+++ b/ie/outer-header-removal.go
@@ -13,6 +13,9 @@ func NewOuterHeaderRemoval(desc, ext uint8) *IE {
 
 // OuterHeaderRemoval returns OuterHeaderRemoval in []byte if the type of IE matches.
 func (i *IE) OuterHeaderRemoval() ([]byte, error) {
+	// The size of the OuterHeaderRemoval IE was one octet in 3GPP TS 29.244 up to V15.3.0,
+	// but it has been changed to two octets since V15.4.0.
+	// For backward compatibility, one octet is also accepted.
 	if len(i.Payload) < 1 {
 		return nil, io.ErrUnexpectedEOF
 	}
@@ -62,6 +65,12 @@ func (i *IE) GTPUExternsionHeaderDeletion() (uint8, error) {
 	v, err := i.OuterHeaderRemoval()
 	if err != nil {
 		return 0, err
+	}
+
+	// If the size of the payload is less than two octets because the original was formatted before
+	// 3GPP TS 29.244 V15.3.0, 0 is returned as GTPUExternsionHeaderDeletion.
+	if len(v) < 2 {
+		return 0, nil
 	}
 
 	return v[1], nil

--- a/ie/outer-header-removal.go
+++ b/ie/outer-header-removal.go
@@ -70,7 +70,7 @@ func (i *IE) GTPUExternsionHeaderDeletion() (uint8, error) {
 	// If the size of the payload is less than two octets because the original was formatted before
 	// 3GPP TS 29.244 V15.3.0, 0 is returned as GTPUExternsionHeaderDeletion.
 	if len(v) < 2 {
-		return 0, nil
+		return 0, io.ErrUnexpectedEOF
 	}
 
 	return v[1], nil


### PR DESCRIPTION
The size of the OuterHeaderRemoval IE was one octet in 3GPP TS
29.244 up to V15.3.0, but it has been changed to two octets since
V15.4.0.

The following commit fixes it so that it does not cause an error
even in OuterHeaderRemoval IE with size 1 according to V15.3.0 or
earlier, but when GTPUExternsionHeaderDeletion is called in
OuterHeaderRemoval IE with size 1, v[1] access and index out of
range error will occur.
https://github.com/wmnsk/go-pfcp/commit/78b3fd79723d4ef6e844acb5e31780867c3247f3

This patch fixes OuterHeaderRemoval IE with size 1 to return 0 when
GTPUExternsionHeaderDeletion is called. But, perhaps it would have
been better to make it return an error.