### PR TITLE
Fix decoding of GateStatusDL

### DIFF
--- a/ie/gate-status.go
+++ b/ie/gate-status.go
@@ -60,7 +60,7 @@ func (i *IE) GateStatusUL() (uint8, error) {
 		return 0, err
 	}
 
-	return (v >> 2) & 0xff, nil
+	return (v >> 2) & 0x01, nil
 }
 
 // GateStatusDL returns GateStatusDL in uint8 if the type of IE matches.
@@ -70,5 +70,5 @@ func (i *IE) GateStatusDL() (uint8, error) {
 		return 0, err
 	}
 
-	return v & 0xff, nil
+	return v & 0x01, nil
 }

--- a/ie/ie_uint8_test.go
+++ b/ie/ie_uint8_test.go
@@ -330,6 +330,16 @@ func TestUint8IEs(t *testing.T) {
 			decoded:     5,
 			decoderFunc: func(i *ie.IE) (uint8, error) { return i.GateStatus() },
 		}, {
+			description: "GateStatus/OpenOpen/GateStatusUL",
+			structured:  ie.NewGateStatus(ie.GateStatusOpen, ie.GateStatusOpen),
+			decoded:     ie.GateStatusOpen,
+			decoderFunc: func(i *ie.IE) (uint8, error) { return i.GateStatusUL() },
+		}, {
+			description: "GateStatus/OpenOpen/GateStatusDL",
+			structured:  ie.NewGateStatus(ie.GateStatusOpen, ie.GateStatusOpen),
+			decoded:     ie.GateStatusOpen,
+			decoderFunc: func(i *ie.IE) (uint8, error) { return i.GateStatusDL() },
+		}, {
 			description: "GateStatus/OpenClosed/GateStatusUL",
 			structured:  ie.NewGateStatus(ie.GateStatusOpen, ie.GateStatusClosed),
 			decoded:     ie.GateStatusOpen,
@@ -337,6 +347,26 @@ func TestUint8IEs(t *testing.T) {
 		}, {
 			description: "GateStatus/OpenClosed/GateStatusDL",
 			structured:  ie.NewGateStatus(ie.GateStatusOpen, ie.GateStatusClosed),
+			decoded:     ie.GateStatusClosed,
+			decoderFunc: func(i *ie.IE) (uint8, error) { return i.GateStatusDL() },
+		}, {
+			description: "GateStatus/ClosedOpen/GateStatusUL",
+			structured:  ie.NewGateStatus(ie.GateStatusClosed, ie.GateStatusOpen),
+			decoded:     ie.GateStatusClosed,
+			decoderFunc: func(i *ie.IE) (uint8, error) { return i.GateStatusUL() },
+		}, {
+			description: "GateStatus/ClosedOpen/GateStatusDL",
+			structured:  ie.NewGateStatus(ie.GateStatusClosed, ie.GateStatusOpen),
+			decoded:     ie.GateStatusOpen,
+			decoderFunc: func(i *ie.IE) (uint8, error) { return i.GateStatusDL() },
+		}, {
+			description: "GateStatus/ClosedClosed/GateStatusUL",
+			structured:  ie.NewGateStatus(ie.GateStatusClosed, ie.GateStatusClosed),
+			decoded:     ie.GateStatusClosed,
+			decoderFunc: func(i *ie.IE) (uint8, error) { return i.GateStatusUL() },
+		}, {
+			description: "GateStatus/ClosedClosed/GateStatusDL",
+			structured:  ie.NewGateStatus(ie.GateStatusClosed, ie.GateStatusClosed),
 			decoded:     ie.GateStatusClosed,
 			decoderFunc: func(i *ie.IE) (uint8, error) { return i.GateStatusDL() },
 		}, {


### PR DESCRIPTION
And also add new tests to cover all possible encoding/decoding combinations.

Test failures without the fix:
```
➜  go-pfcp git:(fix-gate-status-decode) ✗ go test ie/ie_uint8_test.go 
--- FAIL: TestUint8IEs (0.01s)
    --- FAIL: TestUint8IEs/GateStatus/ClosedOpen/GateStatusDL (0.00s)
        ie_uint8_test.go:1245:   uint8(
            -   4,
            +   0,
              )
            
    --- FAIL: TestUint8IEs/GateStatus/ClosedClosed/GateStatusDL (0.00s)
        ie_uint8_test.go:1245:   uint8(
            -   5,
            +   1,
              )
```