### PR TITLE
Make gate status extraction future-proof

### DIFF
--- a/ie/gate-status.go
+++ b/ie/gate-status.go
@@ -60,7 +60,7 @@ func (i *IE) GateStatusUL() (uint8, error) {
 		return 0, err
 	}
 
-	return (v >> 2) & 0x01, nil
+	return (v >> 2) & 0x03, nil
 }
 
 // GateStatusDL returns GateStatusDL in uint8 if the type of IE matches.
@@ -70,5 +70,5 @@ func (i *IE) GateStatusDL() (uint8, error) {
 		return 0, err
 	}
 
-	return v & 0x01, nil
+	return v & 0x03, nil
 }


### PR DESCRIPTION
The fix introduced in #91 extracts only one bit from the UL/DL gate fields. However, according to spec, all bits (2) should be extracted to allow for future uses.

![146141068-e76f9475-75d3-416c-9aa8-d55b263a8b94](https://user-images.githubusercontent.com/3025473/146324875-5efc61ed-f3c4-4475-acfe-6dc26588c3ae.png)

cc @krsna1729 