### PR TITLE
fix: remove - from flag argument on HB example client adn server

### DIFF
--- a/examples/heartbeat/hb-client/main.go
+++ b/examples/heartbeat/hb-client/main.go
@@ -20,7 +20,7 @@ import (
 
 func main() {
 	var (
-		server = flag.String("-s", "127.0.0.2:8805", "server's addr/port")
+		server = flag.String("s", "127.0.0.2:8805", "server's addr/port")
 	)
 	flag.Parse()
 

--- a/examples/heartbeat/hb-server/main.go
+++ b/examples/heartbeat/hb-server/main.go
@@ -20,7 +20,7 @@ import (
 
 func main() {
 	var (
-		listen = flag.String("-s", "127.0.0.2:8805", "addr/port to listen on")
+		listen = flag.String("s", "127.0.0.2:8805", "addr/port to listen on")
 	)
 	flag.Parse()
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

When trying to run HB example client and server, we get an error 
```
goroutine 1 [running]:
flag.(*FlagSet).Var(0xc00008a180, {0x1135010, 0xc000012630}, {0x110cb87, 0x100dca7}, {0x11101b0, 0x1109da0})
        /usr/local/Cellar/go@1.17/1.17.8/libexec/src/flag/flag.go:864 +0x439
flag.(*FlagSet).StringVar(...)
        /usr/local/Cellar/go@1.17/1.17.8/libexec/src/flag/flag.go:762
flag.(*FlagSet).String(0xc00005d370, {0x110cb87, 0x2}, {0x110e5a1, 0xe}, {0x11101b0, 0x16})
        /usr/local/Cellar/go@1.17/1.17.8/libexec/src/flag/flag.go:775 +0xac
flag.String(...)
        /usr/local/Cellar/go@1.17/1.17.8/libexec/src/flag/flag.go:782
main.main()
        /Users/obatalla/testgit/go-pfcp/examples/heartbeat/hb-server/main.go:23 +0x57

Process finished with the exit code 2
```

This error leads to below code on the flag library  [here](https://cs.opensource.google/go/go/+/master:src/flag/flag.go;l=942) which panics if `flag begins with -"`


This PR removes that `-` from the flag on the examples