### PR TITLE
Add SetSequenceNumber() to Message interface

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -52,6 +52,7 @@ type Message interface {
 	Version() int
 	SEID() uint64
 	Sequence() uint32
+	SetSequenceNumber(seq uint32)
 }
 
 // Parse parses the given bytes as Message.


### PR DESCRIPTION
It will be useful to assign and set sequence number for the built message before it is sent out.