### PR TITLE
Add more new flags in ReportingTriggers/UsageReportTrigger IE

### DIFF
--- a/ie/ie_test.go
+++ b/ie/ie_test.go
@@ -373,7 +373,7 @@ func TestIEs(t *testing.T) {
 			ie.NewCreateURR(
 				ie.NewURRID(0xffffffff),
 				ie.NewMeasurementMethod(1, 1, 1),
-				ie.NewReportingTriggers(0x1122),
+				ie.NewReportingTriggers(0x11, 0x22),
 				ie.NewMeasurementPeriod(10*time.Second),
 				ie.NewVolumeThreshold(0x07, 0x3333333333333333, 0x1111111111111111, 0x2222222222222222),
 				ie.NewVolumeQuota(0x07, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff),
@@ -723,7 +723,7 @@ func TestIEs(t *testing.T) {
 			ie.NewUpdateURR(
 				ie.NewURRID(0xffffffff),
 				ie.NewMeasurementMethod(1, 1, 1),
-				ie.NewReportingTriggers(0x1122),
+				ie.NewReportingTriggers(0x11, 0x22),
 				ie.NewMeasurementPeriod(10*time.Second),
 				ie.NewVolumeThreshold(0x07, 0x3333333333333333, 0x1111111111111111, 0x2222222222222222),
 				ie.NewVolumeQuota(0x07, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff),
@@ -1011,8 +1011,8 @@ func TestIEs(t *testing.T) {
 			[]byte{0x00, 0x24, 0x00, 0x04, 0x11, 0x11, 0x11, 0x11},
 		}, {
 			"ReportingTriggers",
-			ie.NewReportingTriggers(0x1122),
-			[]byte{0x00, 0x25, 0x00, 0x02, 0x11, 0x22},
+			ie.NewReportingTriggers(0x11, 0x22, 0x00),
+			[]byte{0x00, 0x25, 0x00, 0x03, 0x11, 0x22, 0x00},
 		}, {
 			"RedirectInformation/URL/1",
 			ie.NewRedirectInformation(ie.RedirectAddrURL, "https://github.com/wmnsk/go-pfcp/"),

--- a/ie/ie_uint16_test.go
+++ b/ie/ie_uint16_test.go
@@ -230,27 +230,6 @@ func TestUint16IEs(t *testing.T) {
 			decoded:     0xffff,
 			decoderFunc: func(i *ie.IE) (uint16, error) { return i.PDRID() },
 		}, {
-			description: "ReportingTriggers",
-			structured:  ie.NewReportingTriggers(0x1122),
-			decoded:     0x1122,
-			decoderFunc: func(i *ie.IE) (uint16, error) { return i.ReportingTriggers() },
-		}, {
-			description: "ReportingTriggers/CreateURR",
-			structured: ie.NewCreateURR(
-				ie.NewURRID(0xffffffff),
-				ie.NewReportingTriggers(0x1122),
-			),
-			decoded:     0x1122,
-			decoderFunc: func(i *ie.IE) (uint16, error) { return i.ReportingTriggers() },
-		}, {
-			description: "ReportingTriggers/UpdateURR",
-			structured: ie.NewUpdateURR(
-				ie.NewURRID(0xffffffff),
-				ie.NewReportingTriggers(0x1122),
-			),
-			decoded:     0x1122,
-			decoderFunc: func(i *ie.IE) (uint16, error) { return i.ReportingTriggers() },
-		}, {
 			description: "TransportLevelMarking",
 			structured:  ie.NewTransportLevelMarking(0x1111),
 			decoded:     0x1111,

--- a/ie/ie_uint32_test.go
+++ b/ie/ie_uint32_test.go
@@ -163,7 +163,7 @@ func TestUint32IEs(t *testing.T) {
 			structured: ie.NewCreateURR(
 				ie.NewURRID(0xffffffff),
 				ie.NewMeasurementMethod(1, 1, 1),
-				ie.NewReportingTriggers(0x1122),
+				ie.NewReportingTriggers(0x11, 0x22),
 				ie.NewMeasurementPeriod(10*time.Second),
 				ie.NewVolumeThreshold(0x07, 0x3333333333333333, 0x1111111111111111, 0x2222222222222222),
 				ie.NewVolumeQuota(0x07, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff),
@@ -209,7 +209,7 @@ func TestUint32IEs(t *testing.T) {
 			structured: ie.NewUpdateURR(
 				ie.NewURRID(0xffffffff),
 				ie.NewMeasurementMethod(1, 1, 1),
-				ie.NewReportingTriggers(0x1122),
+				ie.NewReportingTriggers(0x11, 0x22),
 				ie.NewMeasurementPeriod(10*time.Second),
 				ie.NewVolumeThreshold(0x07, 0x3333333333333333, 0x1111111111111111, 0x2222222222222222),
 				ie.NewVolumeQuota(0x07, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff),
@@ -273,7 +273,7 @@ func TestUint32IEs(t *testing.T) {
 			structured: ie.NewCreateURR(
 				ie.NewURRID(0xffffffff),
 				ie.NewMeasurementMethod(1, 1, 1),
-				ie.NewReportingTriggers(0x1122),
+				ie.NewReportingTriggers(0x11, 0x22),
 				ie.NewMeasurementPeriod(10*time.Second),
 				ie.NewVolumeThreshold(0x07, 0x3333333333333333, 0x1111111111111111, 0x2222222222222222),
 				ie.NewVolumeQuota(0x07, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff),
@@ -319,7 +319,7 @@ func TestUint32IEs(t *testing.T) {
 			structured: ie.NewUpdateURR(
 				ie.NewURRID(0xffffffff),
 				ie.NewMeasurementMethod(1, 1, 1),
-				ie.NewReportingTriggers(0x1122),
+				ie.NewReportingTriggers(0x11, 0x22),
 				ie.NewMeasurementPeriod(10*time.Second),
 				ie.NewVolumeThreshold(0x07, 0x3333333333333333, 0x1111111111111111, 0x2222222222222222),
 				ie.NewVolumeQuota(0x07, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff),

--- a/ie/usage-report-trigger.go
+++ b/ie/usage-report-trigger.go
@@ -123,3 +123,59 @@ func (i *IE) HasTERMR() bool {
 		return false
 	}
 }
+
+// HasEMRRE reports whether an IE has EMRRE bit.
+func (i *IE) HasEMRRE() bool {
+	if len(i.Payload) < 3 {
+		return false
+	}
+
+	switch i.Type {
+	case UsageReportTrigger:
+		u8 := i.Payload[2]
+		return has5thBit(u8)
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest:
+		ies, err := i.UsageReport()
+		if err != nil {
+			return false
+		}
+		for _, x := range ies {
+			if x.Type == UsageReportTrigger {
+				return x.HasEMRRE()
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// HasTEBUR reports whether an IE has TEBUR bit.
+func (i *IE) HasTEBUR() bool {
+	if len(i.Payload) < 3 {
+		return false
+	}
+
+	switch i.Type {
+	case UsageReportTrigger:
+		u8 := i.Payload[2]
+		return has2ndBit(u8)
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest:
+		ies, err := i.UsageReport()
+		if err != nil {
+			return false
+		}
+		for _, x := range ies {
+			if x.Type == UsageReportTrigger {
+				return x.HasTEBUR()
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}

--- a/message/session-establishment-request_test.go
+++ b/message/session-establishment-request_test.go
@@ -95,7 +95,7 @@ func TestSessionEstablishmentRequest(t *testing.T) {
 				ie.NewCreateURR(
 					ie.NewURRID(0xffffffff),
 					ie.NewMeasurementMethod(1, 1, 1),
-					ie.NewReportingTriggers(0x1122),
+					ie.NewReportingTriggers(0x11, 0x22),
 					ie.NewMeasurementPeriod(10*time.Second),
 					ie.NewVolumeThreshold(0x07, 0x3333333333333333, 0x1111111111111111, 0x2222222222222222),
 					ie.NewVolumeQuota(0x07, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff),
@@ -562,7 +562,7 @@ func TestSessionEstablishmentRequest(t *testing.T) {
 				ie.NewCreateURR(
 					ie.NewURRID(0xffffffff),
 					ie.NewMeasurementMethod(1, 1, 1),
-					ie.NewReportingTriggers(0x1122),
+					ie.NewReportingTriggers(0x11, 0x22),
 					ie.NewMeasurementPeriod(10*time.Second),
 					ie.NewVolumeThreshold(0x07, 0x3333333333333333, 0x1111111111111111, 0x2222222222222222),
 					ie.NewVolumeQuota(0x07, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff),

--- a/message/session-modification-request_test.go
+++ b/message/session-modification-request_test.go
@@ -112,7 +112,7 @@ func TestSessionModificationRequest(t *testing.T) {
 				ie.NewCreateURR(
 					ie.NewURRID(0xffffffff),
 					ie.NewMeasurementMethod(1, 1, 1),
-					ie.NewReportingTriggers(0x1122),
+					ie.NewReportingTriggers(0x11, 0x22),
 					ie.NewMeasurementPeriod(10*time.Second),
 					ie.NewVolumeThreshold(0x07, 0x3333333333333333, 0x1111111111111111, 0x2222222222222222),
 					ie.NewVolumeQuota(0x07, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff),
@@ -257,7 +257,7 @@ func TestSessionModificationRequest(t *testing.T) {
 				ie.NewUpdateURR(
 					ie.NewURRID(0xffffffff),
 					ie.NewMeasurementMethod(1, 1, 1),
-					ie.NewReportingTriggers(0x1122),
+					ie.NewReportingTriggers(0x11, 0x22),
 					ie.NewMeasurementPeriod(10*time.Second),
 					ie.NewVolumeThreshold(0x07, 0x3333333333333333, 0x1111111111111111, 0x2222222222222222),
 					ie.NewVolumeQuota(0x07, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff),
@@ -1037,7 +1037,7 @@ func TestSessionModificationRequest(t *testing.T) {
 				ie.NewCreateURR(
 					ie.NewURRID(0xffffffff),
 					ie.NewMeasurementMethod(1, 1, 1),
-					ie.NewReportingTriggers(0x1122),
+					ie.NewReportingTriggers(0x11, 0x22),
 					ie.NewMeasurementPeriod(10*time.Second),
 					ie.NewVolumeThreshold(0x07, 0x3333333333333333, 0x1111111111111111, 0x2222222222222222),
 					ie.NewVolumeQuota(0x07, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff),
@@ -1182,7 +1182,7 @@ func TestSessionModificationRequest(t *testing.T) {
 				ie.NewUpdateURR(
 					ie.NewURRID(0xffffffff),
 					ie.NewMeasurementMethod(1, 1, 1),
-					ie.NewReportingTriggers(0x1122),
+					ie.NewReportingTriggers(0x11, 0x22),
 					ie.NewMeasurementPeriod(10*time.Second),
 					ie.NewVolumeThreshold(0x07, 0x3333333333333333, 0x1111111111111111, 0x2222222222222222),
 					ie.NewVolumeQuota(0x07, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff),


### PR DESCRIPTION
Note: it is an API breaking change:

- NewReportingTriggers must provide multiple uint8 parameter instead of uint16.
- ReportingTriggers return a byte slice instead of uint16.

Align with NewUsageReportTrigger and UsageReportTrigger.