### PR TITLE
fix ApplyAction IE's helper functions

### DIFF
--- a/ie/apply-action.go
+++ b/ie/apply-action.go
@@ -63,16 +63,14 @@ func (i *IE) HasDROP() bool {
 
 // HasFORW reports whether an IE has FORW bit.
 func (i *IE) HasFORW() bool {
-	if len(i.Payload) < 1 {
+	v, err := i.ApplyAction()
+	if err != nil {
 		return false
 	}
-
-	switch i.Type {
-	case ApplyAction:
-		return has2ndBit(i.Payload[0])
-	default:
+	if len(v) < 1 {
 		return false
 	}
+	return has2ndBit(v[0])
 }
 
 // HasBUFF reports whether an IE has BUFF bit.
@@ -93,148 +91,128 @@ func (i *IE) HasBUFF() bool {
 
 // HasNOCP reports whether an IE has NOCP bit.
 func (i *IE) HasNOCP() bool {
-	if len(i.Payload) < 1 {
+	v, err := i.ApplyAction()
+	if err != nil {
 		return false
 	}
-
-	switch i.Type {
-	case ApplyAction:
-		return has4thBit(i.Payload[0])
-	default:
+	if len(v) < 1 {
 		return false
 	}
+	return has4thBit(v[0])
 }
 
 // HasDUPL reports whether an IE has DUPL bit.
 func (i *IE) HasDUPL() bool {
-	if len(i.Payload) < 1 {
+	v, err := i.ApplyAction()
+	if err != nil {
 		return false
 	}
-
-	switch i.Type {
-	case ApplyAction:
-		return has5thBit(i.Payload[0])
-	default:
+	if len(v) < 1 {
 		return false
 	}
+	return has5thBit(v[0])
 }
 
 // HasIPMA reports wether an IE has IPMA bit.
 // This flag has been introduced in release 16.2
 func (i *IE) HasIPMA() bool {
-	if len(i.Payload) < 1 {
+	v, err := i.ApplyAction()
+	if err != nil {
 		return false
 	}
-
-	switch i.Type {
-	case ApplyAction:
-		return has6thBit(i.Payload[0])
-	default:
+	if len(v) < 1 {
 		return false
 	}
+	return has6thBit(v[0])
 }
 
 // HasIPMD reports wether an IE has IPMD bit.
 // This flag has been introduced in release 16.2
 func (i *IE) HasIPMD() bool {
-	if len(i.Payload) < 1 {
+	v, err := i.ApplyAction()
+	if err != nil {
 		return false
 	}
-
-	switch i.Type {
-	case ApplyAction:
-		return has7thBit(i.Payload[0])
-	default:
+	if len(v) < 1 {
 		return false
 	}
+	return has7thBit(v[0])
 }
 
 // HasDFRT reports wether an IE has DFRT bit.
 // This flag has been introduced in release 16.3
 func (i *IE) HasDFRT() bool {
-	if len(i.Payload) < 1 {
+	v, err := i.ApplyAction()
+	if err != nil {
 		return false
 	}
-
-	switch i.Type {
-	case ApplyAction:
-		return has8thBit(i.Payload[0])
-	default:
+	if len(v) < 1 {
 		return false
 	}
+	return has8thBit(v[0])
 }
 
 // HasEDRT reports wether an IE has EDRT bit.
 // This flag has been introduced in release 16.3
 func (i *IE) HasEDRT() bool {
-	if len(i.Payload) < 2 {
+	v, err := i.ApplyAction()
+	if err != nil {
 		return false
 	}
-
-	switch i.Type {
-	case ApplyAction:
-		return has1stBit(i.Payload[1])
-	default:
+	if len(v) < 2 {
 		return false
 	}
+	return has1stBit(v[1])
 }
 
 // HasBDPN reports wether an IE has BDPN bit.
 // This flag has been introduced in release 16.4
 func (i *IE) HasBDPN() bool {
-	if len(i.Payload) < 2 {
+	v, err := i.ApplyAction()
+	if err != nil {
 		return false
 	}
-
-	switch i.Type {
-	case ApplyAction:
-		return has2ndBit(i.Payload[1])
-	default:
+	if len(v) < 2 {
 		return false
 	}
+	return has2ndBit(v[1])
 }
 
 // HasDDPN reports wether an IE has DDPN bit.
 // This flag has been introduced in release 16.4
 func (i *IE) HasDDPN() bool {
-	if len(i.Payload) < 2 {
+	v, err := i.ApplyAction()
+	if err != nil {
 		return false
 	}
-
-	switch i.Type {
-	case ApplyAction:
-		return has3rdBit(i.Payload[1])
-	default:
+	if len(v) < 2 {
 		return false
 	}
+	return has3rdBit(v[1])
 }
 
 // HasFSSM reports wether an IE has FSSM bit.
 // This flag has been introduced in release 17.2
 func (i *IE) HasFSSM() bool {
-	if len(i.Payload) < 2 {
+	v, err := i.ApplyAction()
+	if err != nil {
 		return false
 	}
-
-	switch i.Type {
-	case ApplyAction:
-		return has4thBit(i.Payload[1])
-	default:
+	if len(v) < 2 {
 		return false
 	}
+	return has4thBit(v[1])
 }
 
 // HasMBSU reports wether an IE has MBSU bit.
 // This flag has been introduced in release 17.2
 func (i *IE) HasMBSU() bool {
-	if len(i.Payload) < 2 {
+	v, err := i.ApplyAction()
+	if err != nil {
 		return false
 	}
-
-	switch i.Type {
-	case ApplyAction:
-		return has5thBit(i.Payload[1])
-	default:
+	if len(v) < 2 {
 		return false
 	}
+	return has5thBit(v[1])
 }


### PR DESCRIPTION
The previous PR(https://github.com/wmnsk/go-pfcp/pull/109) breaks helper function original usage, ex: can not use farIe.HasFORW(), only can use applyActionIe.HasFORW().
This PR fixes ApplyAction IE's helper functions (HasFORW/HasNOCP/HasDUPL/HasIPMA/HasIPMD/HasDFRT/HasEDRT/HasBDPN/HasDDPN/HasFSSM/HasMBSU) to be backward-compatible with original usage.