### PR TITLE
Enhance ReportingTriggers related helper functions usage

### DIFF
--- a/ie/reporting-triggers.go
+++ b/ie/reporting-triggers.go
@@ -52,19 +52,21 @@ func (i *IE) ReportingTriggers() ([]byte, error) {
 // HasLIUSA reports whether an IE has LIUSA bit.
 func (i *IE) HasLIUSA() bool {
 	switch i.Type {
-	case ReportingTriggers:
-		if len(i.Payload) < 1 {
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
 			return false
 		}
-
-		u8 := i.Payload[0]
-		return has8thBit(u8)
-	case UsageReportTrigger:
-		if len(i.Payload) < 2 {
+		return has8thBit(v[0])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
 			return false
 		}
-		u8 := i.Payload[1]
-		return has3rdBit(u8)
+		return has3rdBit(v[1])
 	default:
 		return false
 	}
@@ -72,14 +74,22 @@ func (i *IE) HasLIUSA() bool {
 
 // HasDROTH reports whether an IE has DROTH bit.
 func (i *IE) HasDROTH() bool {
-	if len(i.Payload) < 1 {
-		return false
-	}
-
 	switch i.Type {
-	case ReportingTriggers, UsageReportTrigger:
-		u8 := i.Payload[0]
-		return has7thBit(u8)
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
+			return false
+		}
+		return has7thBit(v[0])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
+			return false
+		}
+		return has7thBit(v[0])
 	default:
 		return false
 	}
@@ -87,14 +97,22 @@ func (i *IE) HasDROTH() bool {
 
 // HasSTOPT reports whether an IE has STOPT bit.
 func (i *IE) HasSTOPT() bool {
-	if len(i.Payload) < 1 {
-		return false
-	}
-
 	switch i.Type {
-	case ReportingTriggers, UsageReportTrigger:
-		u8 := i.Payload[0]
-		return has6thBit(u8)
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
+			return false
+		}
+		return has6thBit(v[0])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
+			return false
+		}
+		return has6thBit(v[0])
 	default:
 		return false
 	}
@@ -102,14 +120,22 @@ func (i *IE) HasSTOPT() bool {
 
 // HasSTART reports whether an IE has START bit.
 func (i *IE) HasSTART() bool {
-	if len(i.Payload) < 1 {
-		return false
-	}
-
 	switch i.Type {
-	case ReportingTriggers, UsageReportTrigger:
-		u8 := i.Payload[0]
-		return has5thBit(u8)
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
+			return false
+		}
+		return has5thBit(v[0])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
+			return false
+		}
+		return has5thBit(v[0])
 	default:
 		return false
 	}
@@ -117,14 +143,22 @@ func (i *IE) HasSTART() bool {
 
 // HasQUHTI reports whether an IE has QUHTI bit.
 func (i *IE) HasQUHTI() bool {
-	if len(i.Payload) < 1 {
-		return false
-	}
-
 	switch i.Type {
-	case ReportingTriggers, UsageReportTrigger:
-		u8 := i.Payload[0]
-		return has4thBit(u8)
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
+			return false
+		}
+		return has4thBit(v[0])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
+			return false
+		}
+		return has4thBit(v[0])
 	default:
 		return false
 	}
@@ -132,14 +166,22 @@ func (i *IE) HasQUHTI() bool {
 
 // HasTIMTH reports whether an IE has TIMTH bit.
 func (i *IE) HasTIMTH() bool {
-	if len(i.Payload) < 1 {
-		return false
-	}
-
 	switch i.Type {
-	case ReportingTriggers, UsageReportTrigger:
-		u8 := i.Payload[0]
-		return has3rdBit(u8)
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
+			return false
+		}
+		return has3rdBit(v[0])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
+			return false
+		}
+		return has3rdBit(v[0])
 	default:
 		return false
 	}
@@ -147,14 +189,22 @@ func (i *IE) HasTIMTH() bool {
 
 // HasVOLTH reports whether an IE has VOLTH bit.
 func (i *IE) HasVOLTH() bool {
-	if len(i.Payload) < 1 {
-		return false
-	}
-
 	switch i.Type {
-	case ReportingTriggers, UsageReportTrigger:
-		u8 := i.Payload[0]
-		return has2ndBit(u8)
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
+			return false
+		}
+		return has2ndBit(v[0])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
+			return false
+		}
+		return has2ndBit(v[0])
 	default:
 		return false
 	}
@@ -162,17 +212,29 @@ func (i *IE) HasVOLTH() bool {
 
 // HasPERIO reports whether an IE has PERIO bit.
 func (i *IE) HasPERIO() bool {
-	if len(i.Payload) < 1 {
-		return false
-	}
-
 	switch i.Type {
-	case ReportingTriggers, UsageReportTrigger:
-		u8 := i.Payload[0]
-		return has1stBit(u8)
-	case ReportingFrequency:
-		u8 := i.Payload[0]
-		return has2ndBit(u8)
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
+			return false
+		}
+		return has1stBit(v[0])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
+			return false
+		}
+		return has1stBit(v[0])
+	case QoSMonitoringPerQoSFlowControlInformation,
+		ReportingFrequency:
+		v, err := i.ReportingFrequency()
+		if err != nil {
+			return false
+		}
+		return has2ndBit(v)
 	default:
 		return false
 	}
@@ -181,20 +243,21 @@ func (i *IE) HasPERIO() bool {
 // HasQUVTI reports whether an IE has QUVTI bit.
 func (i *IE) HasQUVTI() bool {
 	switch i.Type {
-	case ReportingTriggers:
-		if len(i.Payload) < 2 {
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
 			return false
 		}
-
-		u8 := i.Payload[1]
-		return has8thBit(u8)
-	case UsageReportTrigger:
-		if len(i.Payload) < 3 {
+		return has8thBit(v[1])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
 			return false
 		}
-
-		u8 := i.Payload[2]
-		return has4thBit(u8)
+		return has4thBit(v[2])
 	default:
 		return false
 	}
@@ -203,20 +266,21 @@ func (i *IE) HasQUVTI() bool {
 // HasIPMJL reports whether an IE has IPMJL bit.
 func (i *IE) HasIPMJL() bool {
 	switch i.Type {
-	case ReportingTriggers:
-		if len(i.Payload) < 2 {
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
 			return false
 		}
-
-		u8 := i.Payload[1]
-		return has7thBit(u8)
-	case UsageReportTrigger:
-		if len(i.Payload) < 3 {
+		return has7thBit(v[1])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
 			return false
 		}
-
-		u8 := i.Payload[2]
-		return has3rdBit(u8)
+		return has3rdBit(v[2])
 	default:
 		return false
 	}
@@ -225,20 +289,21 @@ func (i *IE) HasIPMJL() bool {
 // HasEVEQU reports whether an IE has EVEQU bit.
 func (i *IE) HasEVEQU() bool {
 	switch i.Type {
-	case ReportingTriggers:
-		if len(i.Payload) < 2 {
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
 			return false
 		}
-
-		u8 := i.Payload[1]
-		return has6thBit(u8)
-	case UsageReportTrigger:
-		if len(i.Payload) < 3 {
+		return has6thBit(v[1])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
 			return false
 		}
-
-		u8 := i.Payload[2]
-		return has1stBit(u8)
+		return has1stBit(v[2])
 	default:
 		return false
 	}
@@ -246,17 +311,22 @@ func (i *IE) HasEVEQU() bool {
 
 // HasEVETH reports whether an IE has EVETH bit.
 func (i *IE) HasEVETH() bool {
-	if len(i.Payload) < 2 {
-		return false
-	}
-
 	switch i.Type {
-	case ReportingTriggers:
-		u8 := i.Payload[1]
-		return has5thBit(u8)
-	case UsageReportTrigger:
-		u8 := i.Payload[1]
-		return has8thBit(u8)
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
+			return false
+		}
+		return has5thBit(v[1])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
+			return false
+		}
+		return has8thBit(v[1])
 	default:
 		return false
 	}
@@ -264,17 +334,22 @@ func (i *IE) HasEVETH() bool {
 
 // HasMACAR reports whether an IE has MACAR bit.
 func (i *IE) HasMACAR() bool {
-	if len(i.Payload) < 2 {
-		return false
-	}
-
 	switch i.Type {
-	case ReportingTriggers:
-		u8 := i.Payload[1]
-		return has4thBit(u8)
-	case UsageReportTrigger:
-		u8 := i.Payload[1]
-		return has7thBit(u8)
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
+			return false
+		}
+		return has4thBit(v[1])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
+			return false
+		}
+		return has7thBit(v[1])
 	default:
 		return false
 	}
@@ -282,17 +357,22 @@ func (i *IE) HasMACAR() bool {
 
 // HasENVCL reports whether an IE has ENVCL bit.
 func (i *IE) HasENVCL() bool {
-	if len(i.Payload) < 2 {
-		return false
-	}
-
 	switch i.Type {
-	case ReportingTriggers:
-		u8 := i.Payload[1]
-		return has3rdBit(u8)
-	case UsageReportTrigger:
-		u8 := i.Payload[1]
-		return has6thBit(u8)
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
+			return false
+		}
+		return has3rdBit(v[1])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
+			return false
+		}
+		return has6thBit(v[1])
 	default:
 		return false
 	}
@@ -300,14 +380,22 @@ func (i *IE) HasENVCL() bool {
 
 // HasTIMQU reports whether an IE has TIMQU bit.
 func (i *IE) HasTIMQU() bool {
-	if len(i.Payload) < 2 {
-		return false
-	}
-
 	switch i.Type {
-	case ReportingTriggers, UsageReportTrigger:
-		u8 := i.Payload[1]
-		return has2ndBit(u8)
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
+			return false
+		}
+		return has2ndBit(v[1])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
+			return false
+		}
+		return has2ndBit(v[1])
 	default:
 		return false
 	}
@@ -315,14 +403,22 @@ func (i *IE) HasTIMQU() bool {
 
 // HasVOLQU reports whether an IE has VOLQU bit.
 func (i *IE) HasVOLQU() bool {
-	if len(i.Payload) < 2 {
-		return false
-	}
-
 	switch i.Type {
-	case ReportingTriggers, UsageReportTrigger:
-		u8 := i.Payload[1]
-		return has1stBit(u8)
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
+			return false
+		}
+		return has1stBit(v[1])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
+			return false
+		}
+		return has1stBit(v[1])
 	default:
 		return false
 	}
@@ -331,20 +427,26 @@ func (i *IE) HasVOLQU() bool {
 // HasUPINT reports whether an IE has UPINT bit.
 func (i *IE) HasUPINT() bool {
 	switch i.Type {
-	case ReportingTriggers:
-		if len(i.Payload) < 3 {
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
 			return false
 		}
-
-		u8 := i.Payload[2]
-		return has2ndBit(u8)
-	case UsageReportTrigger:
-		if len(i.Payload) < 3 {
+		if len(v) < 3 {
+			// The 3rd byte only appears in R16
+			// This is for backward-compatibility with R15
 			return false
 		}
-
-		u8 := i.Payload[2]
-		return has6thBit(u8)
+		return has2ndBit(v[2])
+	case UsageReportWithinSessionModificationResponse,
+		UsageReportWithinSessionDeletionResponse,
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
+		if err != nil {
+			return false
+		}
+		return has6thBit(v[2])
 	default:
 		return false
 	}
@@ -353,13 +455,17 @@ func (i *IE) HasUPINT() bool {
 // HasREEMR reports whether an IE has REEMR bit.
 func (i *IE) HasREEMR() bool {
 	switch i.Type {
-	case ReportingTriggers:
-		if len(i.Payload) < 3 {
+	case CreateURR, UpdateURR, ReportingTriggers:
+		v, err := i.ReportingTriggers()
+		if err != nil {
 			return false
 		}
-
-		u8 := i.Payload[2]
-		return has1stBit(u8)
+		if len(v) < 3 {
+			// The 3rd byte only appears in R16
+			// This is for backward-compatibility with R15
+			return false
+		}
+		return has1stBit(v[2])
 	default:
 		return false
 	}

--- a/ie/reporting-triggers.go
+++ b/ie/reporting-triggers.go
@@ -257,6 +257,11 @@ func (i *IE) HasQUVTI() bool {
 		if err != nil {
 			return false
 		}
+		if len(v) < 3 {
+			// The 3rd byte only appears in R16 or newer R15
+			// This is for backward-compatibility with older R15
+			return false
+		}
 		return has4thBit(v[2])
 	default:
 		return false
@@ -280,6 +285,11 @@ func (i *IE) HasIPMJL() bool {
 		if err != nil {
 			return false
 		}
+		if len(v) < 3 {
+			// The 3rd byte only appears in R16 or newer R15
+			// This is for backward-compatibility with older R15
+			return false
+		}
 		return has3rdBit(v[2])
 	default:
 		return false
@@ -301,6 +311,11 @@ func (i *IE) HasEVEQU() bool {
 		UsageReportTrigger:
 		v, err := i.UsageReportTrigger()
 		if err != nil {
+			return false
+		}
+		if len(v) < 3 {
+			// The 3rd byte only appears in R16 or newer R15
+			// This is for backward-compatibility with older R15
 			return false
 		}
 		return has1stBit(v[2])
@@ -444,6 +459,11 @@ func (i *IE) HasUPINT() bool {
 		UsageReportTrigger:
 		v, err := i.UsageReportTrigger()
 		if err != nil {
+			return false
+		}
+		if len(v) < 3 {
+			// The 3rd byte only appears in R16 or newer R15
+			// This is for backward-compatibility with older R15
 			return false
 		}
 		return has6thBit(v[2])

--- a/ie/usage-report-trigger.go
+++ b/ie/usage-report-trigger.go
@@ -15,7 +15,7 @@ func NewUsageReportTrigger(triggerOctets ...uint8) *IE {
 
 // UsageReportTrigger returns UsageReportTrigger in []byte if the type of IE matches.
 func (i *IE) UsageReportTrigger() ([]byte, error) {
-	if len(i.Payload) < 3 {
+	if len(i.Payload) < 2 {
 		return nil, io.ErrUnexpectedEOF
 	}
 
@@ -102,6 +102,11 @@ func (i *IE) HasEMRRE() bool {
 		if err != nil {
 			return false
 		}
+		if len(v) < 3 {
+			// The 3rd byte only appears in R16 or newer R15
+			// This is for backward-compatibility with older R15
+			return false
+		}
 		return has5thBit(v[2])
 	default:
 		return false
@@ -117,6 +122,11 @@ func (i *IE) HasTEBUR() bool {
 		UsageReportTrigger:
 		v, err := i.UsageReportTrigger()
 		if err != nil {
+			return false
+		}
+		if len(v) < 3 {
+			// The 3rd byte only appears in R16 or newer R15
+			// This is for backward-compatibility with older R15
 			return false
 		}
 		return has2ndBit(v[2])

--- a/ie/usage-report-trigger.go
+++ b/ie/usage-report-trigger.go
@@ -42,27 +42,16 @@ func (i *IE) UsageReportTrigger() ([]byte, error) {
 
 // HasIMMER reports whether an IE has IMMER bit.
 func (i *IE) HasIMMER() bool {
-	if len(i.Payload) < 1 {
-		return false
-	}
-
 	switch i.Type {
-	case UsageReportTrigger:
-		u8 := i.Payload[0]
-		return has8thBit(u8)
 	case UsageReportWithinSessionModificationResponse,
 		UsageReportWithinSessionDeletionResponse,
-		UsageReportWithinSessionReportRequest:
-		ies, err := i.UsageReport()
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
 		if err != nil {
 			return false
 		}
-		for _, x := range ies {
-			if x.Type == UsageReportTrigger {
-				return x.HasIMMER()
-			}
-		}
-		return false
+		return has8thBit(v[0])
 	default:
 		return false
 	}
@@ -70,27 +59,16 @@ func (i *IE) HasIMMER() bool {
 
 // HasMONIT reports whether an IE has MONIT bit.
 func (i *IE) HasMONIT() bool {
-	if len(i.Payload) < 2 {
-		return false
-	}
-
 	switch i.Type {
-	case UsageReportTrigger:
-		u8 := i.Payload[1]
-		return has5thBit(u8)
 	case UsageReportWithinSessionModificationResponse,
 		UsageReportWithinSessionDeletionResponse,
-		UsageReportWithinSessionReportRequest:
-		ies, err := i.UsageReport()
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
 		if err != nil {
 			return false
 		}
-		for _, x := range ies {
-			if x.Type == UsageReportTrigger {
-				return x.HasMONIT()
-			}
-		}
-		return false
+		return has5thBit(v[1])
 	default:
 		return false
 	}
@@ -98,27 +76,16 @@ func (i *IE) HasMONIT() bool {
 
 // HasTERMR reports whether an IE has TERMR bit.
 func (i *IE) HasTERMR() bool {
-	if len(i.Payload) < 2 {
-		return false
-	}
-
 	switch i.Type {
-	case UsageReportTrigger:
-		u8 := i.Payload[1]
-		return has4thBit(u8)
 	case UsageReportWithinSessionModificationResponse,
 		UsageReportWithinSessionDeletionResponse,
-		UsageReportWithinSessionReportRequest:
-		ies, err := i.UsageReport()
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
 		if err != nil {
 			return false
 		}
-		for _, x := range ies {
-			if x.Type == UsageReportTrigger {
-				return x.HasTERMR()
-			}
-		}
-		return false
+		return has4thBit(v[1])
 	default:
 		return false
 	}
@@ -126,27 +93,16 @@ func (i *IE) HasTERMR() bool {
 
 // HasEMRRE reports whether an IE has EMRRE bit.
 func (i *IE) HasEMRRE() bool {
-	if len(i.Payload) < 3 {
-		return false
-	}
-
 	switch i.Type {
-	case UsageReportTrigger:
-		u8 := i.Payload[2]
-		return has5thBit(u8)
 	case UsageReportWithinSessionModificationResponse,
 		UsageReportWithinSessionDeletionResponse,
-		UsageReportWithinSessionReportRequest:
-		ies, err := i.UsageReport()
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
 		if err != nil {
 			return false
 		}
-		for _, x := range ies {
-			if x.Type == UsageReportTrigger {
-				return x.HasEMRRE()
-			}
-		}
-		return false
+		return has5thBit(v[2])
 	default:
 		return false
 	}
@@ -154,27 +110,16 @@ func (i *IE) HasEMRRE() bool {
 
 // HasTEBUR reports whether an IE has TEBUR bit.
 func (i *IE) HasTEBUR() bool {
-	if len(i.Payload) < 3 {
-		return false
-	}
-
 	switch i.Type {
-	case UsageReportTrigger:
-		u8 := i.Payload[2]
-		return has2ndBit(u8)
 	case UsageReportWithinSessionModificationResponse,
 		UsageReportWithinSessionDeletionResponse,
-		UsageReportWithinSessionReportRequest:
-		ies, err := i.UsageReport()
+		UsageReportWithinSessionReportRequest,
+		UsageReportTrigger:
+		v, err := i.UsageReportTrigger()
 		if err != nil {
 			return false
 		}
-		for _, x := range ies {
-			if x.Type == UsageReportTrigger {
-				return x.HasTEBUR()
-			}
-		}
-		return false
+		return has2ndBit(v[2])
 	default:
 		return false
 	}


### PR DESCRIPTION
Leverage ReportingTriggers() in helper functions to recursively get the value.
Let helper functions be able to use with any IE, not only with ReportingTriggers IE.