### PR TITLE
Add safe parsing functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ if err != nil {
 }
 
 // decode the message
+// NOTE: when you do this in another goroutine, use ParseSafe() instead
 msg, err := message.Parse(b[:n])
 if err != nil {
 	// handle error

--- a/message/message.go
+++ b/message/message.go
@@ -119,3 +119,15 @@ func Parse(b []byte) (Message, error) {
 	}
 	return m, nil
 }
+
+// ParseSafe safely parses the given bytes as Message by not using the given buffer as it is.
+//
+// When you read messages continuously from the same buffer and parse them in another
+// goroutine, this should be used instead of Parse.
+//
+// This might become a default behavior of Parse in the future.
+func ParseSafe(b []byte) (Message, error) {
+	buf := make([]byte, len(b))
+	copy(buf, b)
+	return Parse(buf)
+}


### PR DESCRIPTION
This PR introduces the parsing functions which copies the given buffer before accessing it to avoid race conditions when the given buffer is used in goroutines. Without this, users need to copy the buffer by themselves like this: 

https://github.com/wmnsk/go-gtp/blob/7977494dd5165da2e89adf986f8c6cf374d9f486/gtpv2/conn.go#L192

_Example is from go-gtp project, as go-pfcp doesn't have networking functionalities yet._

The added functions for IEs are of the same concept. Not needed in most use-cases I guess, though.
