### PR TITLE
Remove ParseSafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ if err != nil {
 }
 
 // decode the message
-// NOTE: when you do this in another goroutine, use ParseSafe() instead
+// NOTE: when you do this in another goroutine, copy the `b` to another slice
+// as the `b` will be overwritten by the next `ReadFromUDP()` call.
 msg, err := message.Parse(b[:n])
 if err != nil {
 	// handle error

--- a/ie/ie.go
+++ b/ie/ie.go
@@ -471,9 +471,9 @@ func (i *IE) valueAs3GPPTimestamp() (time.Time, error) {
 
 // Parse parses b into IE.
 //
-// Note that this function uses the given buffer directly, so not safe to use
+// Note that this function uses the given bytes directly, so not safe to use
 // the buffer after calling this function. When you use the buffer somewhere
-// else, use ParseSafe instead.
+// else, copy it before calling this function.
 func Parse(b []byte) (*IE, error) {
 	i := &IE{}
 	if err := i.UnmarshalBinary(b); err != nil {
@@ -482,21 +482,14 @@ func Parse(b []byte) (*IE, error) {
 	return i, nil
 }
 
-// ParseSafe safely parses b into IE by not using the given buffer directly.
-func ParseSafe(b []byte) (*IE, error) {
-	buf := make([]byte, len(b))
-	copy(buf, b)
-	return Parse(buf)
-}
-
 // ParseMultiIEs decodes multiple IEs at a time.
 // This is easy and useful but slower than decoding one by one.
 // When you don't know the number of IEs, this is the only way to decode them.
 // See benchmarks in diameter_test.go for the detail.
 //
-// Note that this function uses the given buffer directly, so not safe to use
+// Note that this function uses the given bytes directly, so not safe to use
 // the buffer after calling this function. When you use the buffer somewhere
-// else, use ParseMultiIEsSafe instead.
+// else, copy it before calling this function.
 func ParseMultiIEs(b []byte) ([]*IE, error) {
 	var ies []*IE
 	for {
@@ -512,14 +505,6 @@ func ParseMultiIEs(b []byte) ([]*IE, error) {
 		b = b[i.MarshalLen():]
 	}
 	return ies, nil
-}
-
-// ParseMultiIEsSafe safely decodes multiple IEs at a time by not using the
-// given buffer directly.
-func ParseMultiIEsSafe(b []byte) ([]*IE, error) {
-	buf := make([]byte, len(b))
-	copy(buf, b)
-	return ParseMultiIEs(buf)
 }
 
 // UnmarshalBinary parses b into IE.

--- a/message/message.go
+++ b/message/message.go
@@ -119,15 +119,3 @@ func Parse(b []byte) (Message, error) {
 	}
 	return m, nil
 }
-
-// ParseSafe safely parses the given bytes as Message by not using the given buffer as it is.
-//
-// When you read messages continuously from the same buffer and parse them in another
-// goroutine, this should be used instead of Parse.
-//
-// This might become a default behavior of Parse in the future.
-func ParseSafe(b []byte) (Message, error) {
-	buf := make([]byte, len(b))
-	copy(buf, b)
-	return Parse(buf)
-}


### PR DESCRIPTION
because it's not actually safe enough

Resolves #129