### PR TITLE
Handle Additional Supported-Features 

### DIFF
--- a/ie/cp-function-features.go
+++ b/ie/cp-function-features.go
@@ -4,18 +4,22 @@
 
 package ie
 
+import "io"
+
 // NewCPFunctionFeatures creates a new CPFunctionFeatures IE.
-func NewCPFunctionFeatures(features uint8) *IE {
-	return newUint8ValIE(CPFunctionFeatures, features)
+func NewCPFunctionFeatures(features ...uint8) *IE {
+	return New(CPFunctionFeatures, features)
 }
 
-// CPFunctionFeatures returns CPFunctionFeatures in uint8 if the type of IE matches.
-func (i *IE) CPFunctionFeatures() (uint8, error) {
+// CPFunctionFeatures returns CPFunctionFeatures in []byte if the type of IE matches.
+func (i *IE) CPFunctionFeatures() ([]byte, error) {
 	if i.Type != CPFunctionFeatures {
-		return 0, &InvalidTypeError{Type: i.Type}
+		return nil, &InvalidTypeError{Type: i.Type}
 	}
-
-	return i.ValueAsUint8()
+	if len(i.Payload) < 1 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	return i.Payload, nil
 }
 
 // HasLOAD reports whether an IE has LOAD bit.
@@ -40,4 +44,52 @@ func (i *IE) HasOVRL() bool {
 	}
 
 	return has2ndBit(i.Payload[0])
+}
+
+// HasARDR reports whether an IE has ARDR bit.
+func (i *IE) HasARDR() bool {
+	if i.Type != CPFunctionFeatures {
+		return false
+	}
+	if len(i.Payload) < 1 {
+		return false
+	}
+
+	return has7thBit(i.Payload[0])
+}
+
+// HasUIAUR reports whether an IE has UIAUR bit.
+func (i *IE) HasUIAUR() bool {
+	if i.Type != CPFunctionFeatures {
+		return false
+	}
+	if len(i.Payload) < 1 {
+		return false
+	}
+
+	return has8thBit(i.Payload[0])
+}
+
+// HasPSUCC reports whether an IE has PSUCC bit.
+func (i *IE) HasPSUCC() bool {
+	if i.Type != CPFunctionFeatures {
+		return false
+	}
+	if len(i.Payload) < 2 {
+		return false
+	}
+
+	return has1stBit(i.Payload[1])
+}
+
+// HasRPGUR reports whether an IE has RPGUR bit.
+func (i *IE) HasRPGUR() bool {
+	if i.Type != CPFunctionFeatures {
+		return false
+	}
+	if len(i.Payload) < 2 {
+		return false
+	}
+
+	return has2ndBit(i.Payload[1])
 }

--- a/ie/ie_byte_array_test.go
+++ b/ie/ie_byte_array_test.go
@@ -81,6 +81,11 @@ func TestByteArrayIEs(t *testing.T) {
 			),
 			decoded:     []byte{0x04, 0x02},
 			decoderFunc: func(i *ie.IE) ([]byte, error) { return i.ApplyAction() },
+		}, {
+			description: "CPFunctionFeatures",
+			structured:  ie.NewCPFunctionFeatures(0x3f),
+			decoded:     []byte{0x3f},
+			decoderFunc: func(i *ie.IE) ([]byte, error) { return i.CPFunctionFeatures() },
 		},
 	}
 

--- a/ie/ie_byte_array_test.go
+++ b/ie/ie_byte_array_test.go
@@ -86,6 +86,11 @@ func TestByteArrayIEs(t *testing.T) {
 			structured:  ie.NewCPFunctionFeatures(0x3f),
 			decoded:     []byte{0x3f},
 			decoderFunc: func(i *ie.IE) ([]byte, error) { return i.CPFunctionFeatures() },
+		}, {
+			description: "CPFunctionFeatures/2bytes",
+			structured:  ie.NewCPFunctionFeatures(0x3f, 0x01),
+			decoded:     []byte{0x3f, 0x01},
+			decoderFunc: func(i *ie.IE) ([]byte, error) { return i.CPFunctionFeatures() },
 		},
 	}
 

--- a/ie/ie_uint8_test.go
+++ b/ie/ie_uint8_test.go
@@ -141,11 +141,6 @@ func TestUint8IEs(t *testing.T) {
 			decoded:     ie.CauseRequestAccepted,
 			decoderFunc: func(i *ie.IE) (uint8, error) { return i.Cause() },
 		}, {
-			description: "CPFunctionFeatures",
-			structured:  ie.NewCPFunctionFeatures(0x3f),
-			decoded:     0x3f,
-			decoderFunc: func(i *ie.IE) (uint8, error) { return i.CPFunctionFeatures() },
-		}, {
 			description: "CreateBridgeInfoForTSC",
 			structured:  ie.NewCreateBridgeInfoForTSC(1),
 			decoded:     1,


### PR DESCRIPTION
Add the missing Additional Supported-Features field in CPFunctionFeatures, which has been described in rel.16 but not handled correctly. Borrowing the work in https://github.com/wmnsk/go-pfcp/pull/114 by @louisroyer.

