### PR TITLE
Fix ParseMACAddressFields

### DIFF
--- a/ie/mac-address.go
+++ b/ie/mac-address.go
@@ -157,6 +157,7 @@ func (f *MACAddressFields) UnmarshalBinary(b []byte) error {
 		if l < offset+6 {
 			return io.ErrUnexpectedEOF
 		}
+		f.SourceMACAddress = make(net.HardwareAddr, 6)
 		copy(f.SourceMACAddress, b[offset:offset+6])
 		offset += 6
 	}
@@ -165,6 +166,7 @@ func (f *MACAddressFields) UnmarshalBinary(b []byte) error {
 		if l < offset+6 {
 			return io.ErrUnexpectedEOF
 		}
+		f.DestinationMACAddress = make(net.HardwareAddr, 6)
 		copy(f.DestinationMACAddress, b[offset:offset+6])
 		offset += 6
 	}
@@ -173,6 +175,7 @@ func (f *MACAddressFields) UnmarshalBinary(b []byte) error {
 		if l < offset+6 {
 			return io.ErrUnexpectedEOF
 		}
+		f.UpperSourceMACAddress = make(net.HardwareAddr, 6)
 		copy(f.UpperSourceMACAddress, b[offset:offset+6])
 		offset += 6
 	}
@@ -181,6 +184,7 @@ func (f *MACAddressFields) UnmarshalBinary(b []byte) error {
 		if l < offset+6 {
 			return io.ErrUnexpectedEOF
 		}
+		f.UpperDestinationMACAddress = make(net.HardwareAddr, 6)
 		copy(f.UpperDestinationMACAddress, b[offset:offset+6])
 	}
 

--- a/ie/mac_address_test.go
+++ b/ie/mac_address_test.go
@@ -1,0 +1,117 @@
+package ie_test
+
+import (
+	"io"
+	"net"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/wmnsk/go-pfcp/ie"
+)
+
+func TestParseMACAddressFields(t *testing.T) {
+	cases := []struct {
+		description string
+		serialized  []byte
+		structured  *ie.MACAddressFields
+		err         error
+	}{
+		{
+			description: "EmptyPayload",
+			serialized:  []byte{},
+			structured:  nil,
+			err:         io.ErrUnexpectedEOF,
+		},
+		{
+			description: "TooSmallPayload",
+			serialized:  []byte{1},
+			structured:  nil,
+			err:         io.ErrUnexpectedEOF,
+		},
+		{
+			description: "SmallestValidPayload",
+			serialized:  []byte{0, 0},
+			structured:  &ie.MACAddressFields{},
+		},
+		{
+			description: "SourceMACAddress",
+			serialized:  []byte{1, 0, 0, 0, 0, 0, 1},
+			structured: &ie.MACAddressFields{
+				Flags:            0x1,
+				SourceMACAddress: net.HardwareAddr{0, 0, 0, 0, 0, 1},
+			},
+		},
+		{
+			description: "SourceMACAddressTooShort",
+			serialized:  []byte{1, 0},
+			structured:  nil,
+			err:         io.ErrUnexpectedEOF,
+		},
+		{
+			description: "DestinationMACAddress",
+			serialized:  []byte{2, 0, 0, 0, 0, 0, 1},
+			structured: &ie.MACAddressFields{
+				Flags:                 0x2,
+				DestinationMACAddress: net.HardwareAddr{0, 0, 0, 0, 0, 1},
+			},
+		},
+		{
+			description: "DestinationMACAddressTooShort",
+			serialized:  []byte{2, 0},
+			structured:  nil,
+			err:         io.ErrUnexpectedEOF,
+		},
+		{
+			description: "UpperSourceMACAddress",
+			serialized:  []byte{4, 0, 0, 0, 0, 0, 1},
+			structured: &ie.MACAddressFields{
+				Flags:                 0x4,
+				UpperSourceMACAddress: net.HardwareAddr{0, 0, 0, 0, 0, 1},
+			},
+		},
+		{
+			description: "UpperSourceMACAddressTooShort",
+			serialized:  []byte{4, 0},
+			structured:  nil,
+			err:         io.ErrUnexpectedEOF,
+		},
+		{
+			description: "UpperDestinationMACAddress",
+			serialized:  []byte{8, 0, 0, 0, 0, 0, 1},
+			structured: &ie.MACAddressFields{
+				Flags:                      0x8,
+				UpperDestinationMACAddress: net.HardwareAddr{0, 0, 0, 0, 0, 1},
+			},
+		},
+		{
+			description: "UpperDestinationMACAddressTooShort",
+			serialized:  []byte{4, 0},
+			structured:  nil,
+			err:         io.ErrUnexpectedEOF,
+		},
+		{
+			description: "AllCombined",
+			serialized:  []byte{15, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 4},
+			structured: &ie.MACAddressFields{
+				Flags:                      0x0f,
+				SourceMACAddress:           net.HardwareAddr{0, 0, 0, 0, 0, 1},
+				DestinationMACAddress:      net.HardwareAddr{0, 0, 0, 0, 0, 2},
+				UpperSourceMACAddress:      net.HardwareAddr{0, 0, 0, 0, 0, 3},
+				UpperDestinationMACAddress: net.HardwareAddr{0, 0, 0, 0, 0, 4},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			got, err := ie.ParseMACAddressFields(c.serialized)
+			if err != c.err {
+				t.Errorf("expected error %v but got %v", c.err, err)
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(got, c.structured); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When using `ParseMACAddressFields` to parse a MACAddress IE, only the `Flags` field is correctly initialized. All the source/destination/uppersource/upperdestination mac address fields remain empty.

After investigation, it appears that when using copy, the number of elements copied is the `the minimum of
len(src) and len(dst)` - see doc [here](https://cs.opensource.google/go/go/+/refs/tags/go1.21.4:src/builtin/builtin.go;l=156).
But at this point, the MAC address fields are nil. So the copy didn't update the MAC address fields.

The fix proposal here is to initialize each field as a `net.HardwareAddr` of size 6. `net.HardwareAddr` being a type alias for `[]byte`, the MAC address field will have the correct size to be able to copy the content of `b[offset:offset+6]` into it.

I also added unit tests to cover this issue, plus extra test cases around the `ParseMACAddressFields`.
I'm not sure about the convention to follow here. The existing unit tests files seemed to cover generic parsing of IEs. But as this is more a specific parsing function, I opted for putting them under `ie/mac_address_test.go`.
Please let me know In case the unit tests should be moved somewhere else.